### PR TITLE
[#1041] Fix the download operation of `wget`

### DIFF
--- a/init/gravitino/init.sh
+++ b/init/gravitino/init.sh
@@ -3,8 +3,8 @@
 # This software is licensed under the Apache License version 2.
 #
 echo "Start to download the jar package of JDBC"
-wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar -o /root/gravitino/catalogs/jdbc-mysql/libs/mysql-connector-java-8.0.27.jar
-wget https://jdbc.postgresql.org/download/postgresql-42.7.0.jar -o /root/gravitino/catalogs/jdbc-postgresql/libs/postgresql-42.7.0.jar
+wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar -O /root/gravitino/catalogs/jdbc-mysql/libs/mysql-connector-java-8.0.27.jar
+wget https://jdbc.postgresql.org/download/postgresql-42.7.0.jar -O /root/gravitino/catalogs/jdbc-postgresql/libs/postgresql-42.7.0.jar
 cp /root/gravitino/catalogs/jdbc-postgresql/libs/postgresql-42.7.0.jar /root/gravitino/catalogs/lakehouse-iceberg/libs
 cp /root/gravitino/catalogs/jdbc-mysql/libs/mysql-connector-java-8.0.27.jar /root/gravitino/catalogs/lakehouse-iceberg/libs
 echo "Finish downloading"


### PR DESCRIPTION
I have compared the size of jars. cc @jerryshao 

root@e08f12eec983:~/gravitino/catalogs/lakehouse-iceberg# ls -al libs/my*

-rw-r--r-- 1 root root 2475087 Dec  9 08:09 libs/mysql-connector-java-8.0.27.jar
root@e08f12eec983:~/gravitino/catalogs/lakehouse-iceberg# ls -al libs/post*
-rw-r--r-- 1 root root 1077325 Dec  9 08:09 libs/postgresql-42.7.0.jar

 ls -al mysql-connector-java-8.0.27.jar 
-rw-r--r--@ 1   staff  2475087 12  9 16:04 mysql-connector-java-8.0.27.jar
ls -al postgresql-42.7.0.jar 
-rw-r--r--@ 1 staff  1077325 12  9 16:06 postgresql-42.7.0.jar