### PR TITLE
[#6] Optimize the playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ WITH (
 INSERT INTO "metalake_demo.catalog_demo".db1.table_001 (name, salary) VALUES ('sam', '11');
 
 SELECT * FROM "metalake_demo.catalog_demo".db1.table_001;
+
+SHOW SCHEMAS from "metalake_demo.catalog_demo";
+
+DESCRIBE "metalake_demo.catalog_demo".db1.table_001;
+
+SHOW TABLES from "metalake_demo.catalog_demo".db1;
 ```
 
 ### Cross-catalog queries

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
   hive:
     image: datastrato/hive:2.7.3-no-yarn
     ports:
-      - "3306:3306"
+      - "3307:3306"
       - "9000:9000"
       - "9083:9083"
     container_name: playground-hive
@@ -75,7 +75,7 @@ services:
 
   postgresql:
     image: postgres:13
-    container_name: postgresql
+    container_name: playground-postgresql
     restart: always
     environment:
       POSTGRES_USER: postgres
@@ -93,9 +93,9 @@ services:
 
   mysql:
     image: mysql:8.0
-    container_name: mysql
+    container_name: playground-mysql
     ports:
-      - "3307:3306"
+      - "3306:3307"
     volumes:
       - ./init/mysql:/docker-entrypoint-initdb.d/
     environment:


### PR DESCRIPTION
1. Change the container name of MySQL and PostgreSQL
2. Change the port, MySQL container uses 3306. I can't close the port in the Hive image, so I change it to 3307.
3. Add more simple queries