### PR TITLE
[#17] Upgrade gravitino version 0.3.1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
           memory: 3G
 
   gravitino:
-    image: datastrato/gravitino:0.3.0
+    image: datastrato/gravitino:0.3.1
     entrypoint: /bin/bash /tmp/gravitino/init.sh
     ports:
       - "8090:8090"
@@ -49,7 +49,7 @@ services:
       retries: 5
 
   trino:
-    image: datastrato/trino:426-gravitino-0.3.0
+    image: datastrato/trino:426-gravitino-0.3.1
     ports:
       - "8080:8080"
     container_name: playground-trino


### PR DESCRIPTION
Gravitino 0.3.1 is released. We upgrade the version of playground. This version fixed many issues. You can see the release note. https://github.com/datastrato/gravitino/releases/tag/v0.3.1