### PR TITLE
[#58] fix: check MySQL readiness before start Gravitino in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,8 @@ services:
     depends_on:
       hive :
         condition: service_healthy
+      mysql :
+        condition: service_healthy
     volumes:
       - ./healthcheck:/tmp/healthcheck
       - ./init/gravitino:/tmp/gravitino
@@ -132,6 +134,11 @@ services:
         limits:
           cpus: "1"
           memory: 500M
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -p ${MYSQL_ROOT_PASSWORD}"]
+      interval: 5s
+      timeout: 60s
+      retries: 5
 
   spark:
     image: spark:3.4.1-scala2.12-java11-ubuntu


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modified docker-compose.yaml:
1. Add MySQL healthy check
2. Add mysql to gravitino's `depends_on` filed


### Why are the changes needed?

The gravitino process will down if the catalog backend(MySQL) is not ready.

Fix: #58

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
1. Run `./launch-playground.sh gravitino`
2. Check http://127.0.0.1:8090/ui/metalakes or check the Gravitino process is running in container

