### PR TITLE
[Enhancement] Change exposed ports to avoid possible conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ LlamaIndex as a unified data source, then use LlamaIndex and LLM to query both t
 non-tabular data with one natural language query.
 
 The demo is located in the `jupyter` folder, you can open the `gravitino_llama_index_demo.ipynb`
-demo via Jupyter Notebook by [http://localhost:8888](http://localhost:8888).
+demo via Jupyter Notebook by [http://localhost:18888](http://localhost:18888).
 
 The scenario of this demo is that basic structured city statistics data is stored in MySQL, and
 detailed city introductions are stored in PDF files. The user wants to know the answers to the

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ The playground runs a number of services. The TCP ports used may clash with exis
 | Docker container      | Ports used           |
 |-----------------------|----------------------|
 | playground-gravitino  | 8090 9001            |
-| playground-hive       | 3307 9000 9083 50070 |
-| playground-mysql      | 3306                 |
-| playground-postgresql | 5342                 |
-| playground-trino      | 8080                 |
-| playground-jupyter    | 8888                 |
+| playground-hive       | 3307 9003 9084 50071 |
+| playground-mysql      | 13306                |
+| playground-postgresql | 15342                |
+| playground-trino      | 18080                |
+| playground-jupyter    | 18888                |
 
 ## Start playground
 
@@ -77,7 +77,7 @@ trino@container_id:/$ trino
 
 ### Using Jupiter Notebook
 
-1. Open the Jupyter Notebook in the browser at [http://localhost:8888](http://localhost:8888).
+1. Open the Jupyter Notebook in the browser at [http://localhost:18888](http://localhost:18888).
 
 2. Open the `gravitino-trino-example.ipynb` notebook.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,9 +22,9 @@ services:
     image: datastrato/hive:2.7.3-no-yarn
     ports:
       - "3307:3306"
-      - "9000:9000"
-      - "9083:9083"
-      - "50070:50070"
+      - "9003:9000"
+      - "9084:9083"
+      - "50071:50070"
     container_name: playground-hive
     environment:
       - HADOOP_USER_NAME=root
@@ -71,7 +71,7 @@ services:
   trino:
     image: datastrato/trino:435-gravitino-0.5.1
     ports:
-      - "8080:8080"
+      - "18080:8080"
     container_name: playground-trino
     environment:
       - HADOOP_USER_NAME=root
@@ -102,7 +102,7 @@ services:
       POSTGRES_PASSWORD: postgres
       ALLOW_IP_RANGE: 0.0.0.0/0
     ports:
-      - "5432:5432"
+      - "15432:5432"
     volumes:
       - ./init/postgres:/docker-entrypoint-initdb.d/
     deploy:
@@ -115,7 +115,7 @@ services:
     image: mysql:8.0
     container_name: playground-mysql
     ports:
-      - "3306:3306"
+      - "13306:3306"
     volumes:
       - ./init/mysql:/docker-entrypoint-initdb.d/
     environment:
@@ -147,7 +147,7 @@ services:
     environment:
       - HADOOP_USER_NAME=root
     ports:
-      - "4040:4040"
+      - "14040:4040"
     volumes:
       - ./init/spark:/tmp/spark
     deploy:
@@ -160,7 +160,7 @@ services:
     image: jupyter/minimal-notebook 
     container_name: playground-jupyter
     ports:
-      - 8888:8888
+      - 18888:8888
     volumes:
       - ./init/jupyter:/tmp/gravitino
     entrypoint: /bin/bash /tmp/gravitino/init.sh


### PR DESCRIPTION
See issue description: [ #60](https://github.com/apache/gravitino-playground/issues/60)

In this PR, I changed the port to services' non-default port (exclude Gravitino), this will avoid conflict if user already runs a service in local, such as mysql, pg, spark, trino, jupyter etc. I manually tested it, works well.