### PR TITLE
[Bug] Avoid OOM (Out of Memory) for Playground-gravitino

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
       resources:
         limits:
           cpus: "0.5"
-          memory: 500M
+          memory: 1G
     healthcheck:
       test: ["CMD", "/tmp/healthcheck/gravitino-healthcheck.sh"]
       interval: 5s

--- a/init/gravitino/gravitino.env.sh
+++ b/init/gravitino/gravitino.env.sh
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Debug Gravitino server
+# export GRAVITINO_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000 -Dlog4j2.debug=true"
+
+# export JAVA_HOME
+# export GRAVITINO_HOME
+# export GRAVITINO_CONF_DIR
+# export GRAVITINO_LOG_DIR     # Where log files are stored.  PWD by default.
+# export GRAVITINO_MEM         # Gravitino jvm mem options Default -Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=512m
+export GRAVITINO_MEM=-Xms512m -Xmx512m -XX:MaxMetaspaceSize=256m

--- a/init/gravitino/init.sh
+++ b/init/gravitino/init.sh
@@ -22,6 +22,7 @@ wget https://jdbc.postgresql.org/download/postgresql-42.7.0.jar -O /root/graviti
 cp /root/gravitino/catalogs/jdbc-postgresql/libs/postgresql-42.7.0.jar /root/gravitino/catalogs/lakehouse-iceberg/libs
 cp /root/gravitino/catalogs/jdbc-mysql/libs/mysql-connector-java-8.0.27.jar /root/gravitino/catalogs/lakehouse-iceberg/libs
 cp /tmp/gravitino/gravitino.conf /root/gravitino/conf
+cp /tmp/gravitino/gravitino.env.sh /root/gravitino/conf
 echo "Finish downloading"
 echo "Start the Gravitino Server"
 /bin/bash /root/gravitino/bin/gravitino.sh start


### PR DESCRIPTION
Add Gravitino jvm mem options to prevent the Gravitino Server process from being killed by the kernel's OOM killer.

gravitino.env.sh.template
```
# export GRAVITINO_MEM         # Gravitino jvm mem options Default -Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=512m
```
docker-compose.yaml
```
  gravitino:
    image: datastrato/gravitino:0.5.1
    deploy:
      resources:
        limits:
          cpus: "0.5"
          memory: 500m
```

```
[四 8月 22 10:12:09 2024] [1439660]     0 1439660  1702258   135715  1871872     3968             0 java
[四 8月 22 10:12:09 2024] oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=docker-xxxxxxx.scope,mems_allowed=0,oom_memcg=/system.slice/docker-xxxxxxx.scope,task_memcg=/system.slice/docker-xxxxxxx.scope,task=java,pid=1439660,uid=0
[四 8月 22 10:12:09 2024] Memory cgroup out of memory: Killed process 1439660 (java) total-vm:6809032kB, anon-rss:504204kB, file-rss:38656kB, shmem-rss:0kB, UID:0 pgtables:1828kB oom_score_adj:0
```
