### PR TITLE
Change exposed ports to avoid possible conflicts, based on last pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The playground runs a number of services. The TCP ports used may clash with exis
 | Docker container      | Ports used           |
 |-----------------------|----------------------|
 | playground-gravitino  | 8090 9001            |
-| playground-hive       | 3307 9003 9084 50071 |
+| playground-hive       | 3307 19000 19083 60070 |
 | playground-mysql      | 13306                |
 | playground-postgresql | 15342                |
 | playground-trino      | 18080                |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,9 +22,9 @@ services:
     image: datastrato/hive:2.7.3-no-yarn
     ports:
       - "3307:3306"
-      - "9003:9000"
-      - "9084:9083"
-      - "50071:50070"
+      - "19000:9000"
+      - "19083:9083"
+      - "60070:50070"
     container_name: playground-hive
     environment:
       - HADOOP_USER_NAME=root


### PR DESCRIPTION
In the previous PR (https://github.com/apache/gravitino-playground/pull/65), xiaojin gave a suggestion on the hive container ports, +10000 to avoid conflicts. So I raised this PR. Has tested in my local desktop, it has no impacts on the playground.

Related issue is:
https://github.com/apache/gravitino-playground/issues/60 