### PR TITLE
[MINOR] Fix iceberg catalog backend name

### DIFF
--- a/init/gravitino/gravitino.conf
+++ b/init/gravitino/gravitino.conf
@@ -69,10 +69,8 @@ gravitino.auxService.iceberg-rest.host = 0.0.0.0
 # Iceberg REST service http port
 gravitino.auxService.iceberg-rest.httpPort = 9001
 gravitino.auxService.iceberg-rest.catalog-backend = jdbc
-gravitino.auxService.iceberg-rest.catalog-backend-name = catalog_iceberg
 gravitino.auxService.iceberg-rest.uri = jdbc:mysql://mysql:3306/db
 gravitino.auxService.iceberg-rest.warehouse = hdfs://hive:9000/user/iceberg/warehouse/
 gravitino.auxService.iceberg-rest.jdbc.user = mysql
 gravitino.auxService.iceberg-rest.jdbc.password = mysql
 gravitino.auxService.iceberg-rest.jdbc-driver = com.mysql.cj.jdbc.Driver
-gravitino.auxService.iceberg-rest.catalog-backend-name = catalog_iceberg


### PR DESCRIPTION
After https://github.com/apache/gravitino/pull/4900,  the default  Iceberg catalog backend name is `jdbc` not Gravitino catalog name