### PR TITLE
[Enhancement] Add install.sh script to automate setup and execution of gravitino-playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Depending on your network and computer, startup time may take 3-5 minutes. Once 
 
 ## Prerequisites
 
-Install Git, Docker, Docker Compose.
+Install Git (optional), Docker, Docker Compose.
 
 ## System Resource Requirements
 
@@ -48,7 +48,12 @@ The playground runs a number of services. The TCP ports used may clash with exis
 
 ## Playground usage
 
-### Launch playground
+### One curl command launch playground
+```shell
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/apache/gravitino-playground/HEAD/install.sh)"
+```
+
+### Use git download and launch playground
 
 ```shell
 git clone git@github.com:apache/gravitino-playground.git

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Check if Docker is installed
+if ! command -v docker &> /dev/null
+then
+    echo "Docker is not installed. Please install Docker before proceeding."
+    exit 1
+fi
+
+# Check if Docker Compose is installed
+if ! command -v docker-compose &> /dev/null
+then
+    echo "Docker Compose is not installed. Please install Docker Compose before proceeding."
+    exit 1
+fi
+
+# Download the source code for gravitino-playground directly from GitHub.
+echo "Downloading gravitino-playground..."
+curl -L -O https://github.com/apache/gravitino-playground/archive/refs/heads/main.zip
+unzip main.zip
+
+while true; do
+    # Prompt the user
+    read -p "Would you like to run gravitino-playground immediately? [Y/N]: " choice
+
+    # Convert choice to uppercase using `tr`
+    choice=$(echo "$choice" | tr '[:lower:]' '[:upper:]')
+
+    if [[ "$choice" == "Y" ]]; then
+        echo "Starting gravitino-playground..."
+        cd ./gravitino-playground-main && ./playground.sh start
+        break
+    elif [[ "$choice" == "N" ]]; then
+        echo "Download complete. You can start gravitino-playground later by running './playground.sh start'."
+        break
+    else
+        echo "Invalid input. Please enter Y or N."
+    fi
+done

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 
 # Check if Docker is installed
 if ! command -v docker &> /dev/null

--- a/install.sh
+++ b/install.sh
@@ -20,8 +20,8 @@
 
 # Download the source code for gravitino-playground directly from GitHub.
 echo "Downloading gravitino-playground..."
-curl -L -O https://github.com/apache/gravitino-playground/archive/refs/heads/main.zip
-unzip main.zip
+curl -L -o gravitino-playground-main.zip https://github.com/apache/gravitino-playground/archive/refs/heads/main.zip
+unzip gravitino-playground-main.zip
 
 while true; do
     # Prompt the user

--- a/install.sh
+++ b/install.sh
@@ -18,20 +18,6 @@
 # under the License.
 #
 
-# Check if Docker is installed
-if ! command -v docker &> /dev/null
-then
-    echo "Docker is not installed. Please install Docker before proceeding."
-    exit 1
-fi
-
-# Check if Docker Compose is installed
-if ! command -v docker-compose &> /dev/null
-then
-    echo "Docker Compose is not installed. Please install Docker Compose before proceeding."
-    exit 1
-fi
-
 # Download the source code for gravitino-playground directly from GitHub.
 echo "Downloading gravitino-playground..."
 curl -L -O https://github.com/apache/gravitino-playground/archive/refs/heads/main.zip


### PR DESCRIPTION
## Background
Add install script to automate setup and execution.

## Change
- add install.sh

## Test 
Users can run install.sh in their local environment using the following command:
```
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/apache/gravitino-playground/HEAD/install.sh)"
```

## Reference
- https://akarshseggemu.medium.com/bash-script-to-check-docker-installation-0a51f90d27e1
- https://gist.github.com/jwebcat/5122366
- https://stackoverflow.com/questions/16261100/cant-download-github-project-with-curl-command