### PR TITLE
[#100] fix spark sql client insert data failed

### DIFF
--- a/init/spark/spark-defaults.conf
+++ b/init/spark/spark-defaults.conf
@@ -27,5 +27,5 @@ spark.sql.catalog.catalog_rest.type rest
 spark.sql.catalog.catalog_rest.uri http://gravitino:9001/iceberg/
 spark.locality.wait.node 0
 spark.sql.warehouse.dir hdfs://hive:9000/user/hive/warehouse
-spark.sql.hive.metastore.jars path
-spark.sql.hive.metastore.jars.path file:///opt/spark/jars/*
+spark.sql.catalog.catalog_hive.spark.sql.hive.metastore.jars path
+spark.sql.catalog.catalog_hive.spark.sql.hive.metastore.jars.path file:///opt/spark/jars/*

--- a/playground.sh
+++ b/playground.sh
@@ -17,6 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+set -x
+
 playground_dir="$(dirname "${BASH_SOURCE-$0}")"
 playground_dir="$(
   cd "${playground_dir}" >/dev/null


### PR DESCRIPTION
After #88 , spark sql client couldn't insert data, The spark configuration in #88 is not enough, should add hive metastore uri if setting `spark.sql.hive.metastore.jars` to `path`.  I'm not sure the root cause of problem, there're some thread level session cache in Spark/Hive, this PR optimize the configuration just affect hive_catalog.