### PR TITLE
[MINOR] Fix the issue of starting in Linux

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,11 +52,6 @@ services:
       timeout: 60s
       retries: 5
       start_period: 120s
-    deploy:
-      resources:
-        limits:
-          cpus: "0.5"
-          memory: 500M
 
   gravitino:
     image: apache/gravitino:0.8.0-incubating


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the issue of starting in Linux

### Why are the changes needed?

Linux Docker environment will kill the process of Ranger if we don't give enough memory. To align to other services, we remove the resource limitation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

By hand.