### PR TITLE
[#131] docs(README): add missing container ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The playground runs several services. The TCP ports used may clash with existing
 | playground-hive       | 3307 19000 19083 60070 |
 | playground-ranger     | 6080                   |
 | playground-mysql      | 13306                  |
-| playground-postgresql | 15342                  |
+| playground-postgresql | 15432                  |
 | playground-trino      | 18080                  |
 | playground-jupyter    | 18888                  |
 | playground-prometheus | 19090                  |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The playground runs several services. The TCP ports used may clash with existing
 | --------------------- | ---------------------- |
 | playground-gravitino  | 8090 9001              |
 | playground-hive       | 3307 19000 19083 60070 |
+| playground-ranger     | 6080                   |
 | playground-mysql      | 13306                  |
 | playground-postgresql | 15342                  |
 | playground-trino      | 18080                  |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The playground runs several services. The TCP ports used may clash with existing
 | playground-hive       | 3307 19000 19083 60070 |
 | playground-ranger     | 6080                   |
 | playground-mysql      | 13306                  |
+| playground-spark      | 14040                  |
 | playground-postgresql | 15432                  |
 | playground-trino      | 18080                  |
 | playground-jupyter    | 18888                  |


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add missing ranger container port
2. Add missing spark container port
3. Fix postgresql port typo 

### Why are the changes needed?

1. Ranger and Spark container ports are missing
3. Typo: postgresql port 15342 (instead of 15432)

Fix: #131 

### Does this PR introduce _any_ user-facing change?

_None_

### How was this patch tested?

Not required.
