### PR TITLE
[#135] improvement: Update Hive image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@
 #
 services:
   hive:
-    image: apache/gravitino-playground:hive-0.1.14
+    image: apache/gravitino-playground:hive-0.1.15
     ports:
       - "3307:3306"
       - "19000:9000"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the docker Hive playground image from 0.1.14 to 0.1.15

### Why are the changes needed?

Please see https://github.com/apache/gravitino/issues/6612

Fix: #135 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally. 
