### PR TITLE
[#139] Improvement: externalize Gravitino metadata and Jupyter notebooks outside of containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/.DS_Store
 **/packages
 **/*.log
+data/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,7 +70,7 @@ services:
     volumes:
       - ./healthcheck:/tmp/healthcheck
       - ./init/gravitino:/tmp/gravitino
-      - ./data/gravitino/data:/root/gravitino/data
+      - ./data/gravitino/db:/root/gravitino/data
     healthcheck:
       test: ["CMD", "/tmp/healthcheck/gravitino-healthcheck.sh"]
       interval: 5s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,6 +70,7 @@ services:
     volumes:
       - ./healthcheck:/tmp/healthcheck
       - ./init/gravitino:/tmp/gravitino
+      - ./data/gravitino/data:/root/gravitino/data
     healthcheck:
       test: ["CMD", "/tmp/healthcheck/gravitino-healthcheck.sh"]
       interval: 5s
@@ -165,6 +166,7 @@ services:
       - "18888:8888"
     volumes:
       - ./init/jupyter:/tmp/gravitino
+      - ./data/jupyter/data:/home/jovyan
     entrypoint: /bin/bash /tmp/gravitino/init.sh
     depends_on:
       hive:

--- a/init/gravitino/init.sh
+++ b/init/gravitino/init.sh
@@ -24,7 +24,14 @@ cp /root/gravitino/catalogs/jdbc-mysql/libs/mysql-connector-java-8.0.27.jar /roo
 
 cp /root/gravitino/catalogs/jdbc-postgresql/libs/postgresql-42.2.7.jar /root/gravitino/iceberg-rest-server/libs
 cp /root/gravitino/catalogs/jdbc-mysql/libs/mysql-connector-java-8.0.27.jar /root/gravitino/iceberg-rest-server/libs
-cp /tmp/gravitino/gravitino.conf /root/gravitino/conf
+
+
+if test -e "/root/gravitino/conf/gravitino.conf"; then
+    echo "/root/gravitino/conf/gravitino.conf exists. Skip copying."
+else
+    cp /tmp/gravitino/gravitino.conf /root/gravitino/conf
+fi
+
 
 echo "Finish downloading"
 echo "Start the Gravitino Server"

--- a/init/jupyter/init.sh
+++ b/init/jupyter/init.sh
@@ -17,10 +17,16 @@
 # under the License.
 #
 
-if [ -z "$RANGER_ENABLE" ]; then
-  cp -r /tmp/gravitino/*.ipynb /home/jovyan
+if [ -n "$(find /home/jovyan -maxdepth 1 -name "*.ipynb" -print -quit)" ]; then
+    echo "Already have .ipynb files in the directory, skip copying"
 else
-  cp -r /tmp/gravitino/authorization/*.ipynb /home/jovyan
+    echo "No .ipynb files in the directory, copy the default .ipynb files"
+
+    if [ -z "$RANGER_ENABLE" ]; then
+      cp -r /tmp/gravitino/*.ipynb /home/jovyan
+    else
+      cp -r /tmp/gravitino/authorization/*.ipynb /home/jovyan
+    fi
 fi
 
 start-notebook.sh --NotebookApp.token=''


### PR DESCRIPTION
### What changes were proposed in this pull request?

Mount a local folder to the Gravitino and Jupyter container, which persistents the metadata of Gravitino (h2 db file by default) and the notebooks of Jupyter. So that they won't be lost when the containers be re-created.

### Why are the changes needed?

No changes for other part. 

If user do want to cleanup the metadata, they need manually clean up the "data/gravitino" or "data/jupyter" folder under the playground folder.

Fix: #139

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
I tested it in my local. When I stop, drop the container, and then restart, previous metadata of Gravitino and Jupyter were kept.
