### PR TITLE
[#152] fix: Fix the directory permission so Jupyter can start properly

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -169,6 +169,7 @@ services:
 
   jupyter:
     image: jupyter/pyspark-notebook:${JUPYTER_IMAGE_TAG}
+    user: root
     container_name: playground-jupyter
     ports:
       - "18888:8888"
@@ -177,6 +178,9 @@ services:
       - ./data/jupyter/data:/home/jovyan
     entrypoint: /bin/bash /tmp/gravitino/init.sh
     environment:
+      - CHOWN_HOME=yes
+      - CHOWN_HOME_OPTS=-R
+      - GRANT_SUDO=yes
       - SPARK_CONNECTOR_JAR=${SPARK_CONNECTOR_JAR}
     depends_on:
       hive:


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

This PR fixes the owner of /home/jovyan in the Jupyter container at startup.

### Why are the changes needed?

Without this change, that directory is owned by root and Jupyter fails to start as follows:

```
$ sudo rm -rf data
$ docker system prune -f
$ docker volume rm $(docker volume ls -q)
$ ./playground.sh start

(snip)

[+] up 11/11
 ✔ Network gravitino-playground_default Created                                                                                                                                           0.0s
 ✔ Container playground-postgresql      Started                                                                                                                                           0.2s
 ✔ Container playground-ranger          Healthy                                                                                                                                          31.4s
 ✔ Container playground-hive            Healthy                                                                                                                                          32.0s
 ✔ Container playground-mysql           Healthy                                                                                                                                          10.9s
 ✔ Container playground-grafana         Started                                                                                                                                           0.3s
 ✔ Container playground-prometheus      Started                                                                                                                                           0.3s
 ✔ Container playground-gravitino       Healthy                                                                                                                                          41.9s
 ✔ Container playground-spark           Started                                                                                                                                          42.1s
 ✔ Container playground-trino           Started                                                                                                                                          42.1s
 ✔ Container playground-jupyter         Started                                                                                                                                          42.1s
[INFO] Check log details: /home/sekikn/repos/apache/gravitino-playground/playground-2026070115441782888257.log
$ docker ps -f status=exited
CONTAINER ID   IMAGE                                  COMMAND                  CREATED         STATUS                     PORTS     NAMES
f042a82231ee   jupyter/pyspark-notebook:spark-3.4.1   "/bin/bash /tmp/grav…"   4 minutes ago   Exited (1) 3 minutes ago             playground-jupyter
$ docker logs playground-jupyter

(snip)

PermissionError: [Errno 13] Permission denied: '/home/jovyan/.local'
```

Fix: #152 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Ran `./playground.sh start` locally, as follows:

```
$ ./playground.sh start

(snip)

[+] up 11/11
 ✔ Network gravitino-playground_default Created                                                                                                                                                                                                                                                                                                                                                                                                                                         0.0s
 ✔ Container playground-prometheus      Started                                                                                                                                                                                                                                                                                                                                                                                                                                         0.3s
 ✔ Container playground-mysql           Healthy                                                                                                                                                                                                                                                                                                                                                                                                                                        10.8s
 ✔ Container playground-hive            Healthy                                                                                                                                                                                                                                                                                                                                                                                                                                        32.0s
 ✔ Container playground-grafana         Started                                                                                                                                                                                                                                                                                                                                                                                                                                         0.3s
 ✔ Container playground-ranger          Healthy                                                                                                                                                                                                                                                                                                                                                                                                                                        31.3s
 ✔ Container playground-postgresql      Started                                                                                                                                                                                                                                                                                                                                                                                                                                         0.4s
 ✔ Container playground-gravitino       Healthy                                                                                                                                                                                                                                                                                                                                                                                                                                        41.9s
 ✔ Container playground-trino           Started                                                                                                                                                                                                                                                                                                                                                                                                                                        42.1s
 ✔ Container playground-spark           Started                                                                                                                                                                                                                                                                                                                                                                                                                                        42.1s
 ✔ Container playground-jupyter         Started                                                                                                                                                                                                                                                                                                                                                                                                                                        42.1s
[INFO] Check log details: /home/sekikn/repos/apache/gravitino-playground/playground-2026070115541782888844.log
sekikn@sekikn-MotherBoard-Series:~/repos/apache/gravitino-playground$ docker ps -f name=playground-jupyter
CONTAINER ID   IMAGE                                  COMMAND                  CREATED         STATUS                   PORTS                                                     NAMES
ec2f48e7385a   jupyter/pyspark-notebook:spark-3.4.1   "/bin/bash /tmp/grav…"   2 minutes ago   Up 2 minutes (healthy)   4040/tcp, 0.0.0.0:18888->8888/tcp, [::]:18888->8888/tcp   playground-jupyter
```